### PR TITLE
Inelegant hack around lack of --templates arg in cfn-lint

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,5 +1,5 @@
 - id: cfnlint
   name: cfnlint
-  entry: cfn-lint
+  entry: cfn-lint-wrapper
   language: python
   files: \.template$

--- a/cfn_lint_pre_commit/cfn_lint_wrapper.py
+++ b/cfn_lint_pre_commit/cfn_lint_wrapper.py
@@ -1,0 +1,19 @@
+import argparse
+import subprocess
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('filenames', nargs='*')
+    args = parser.parse_args(argv)
+
+    retcode = 0
+    for filename in args.filenames:
+        if subprocess.call(['cfn-lint', filename]) != 0:
+            retcode = 1
+
+    return retcode
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,15 @@
+from setuptools import find_packages
 from setuptools import setup
 
 
 setup(
-    name='pre_commit_dummy_package',
+    name='cfn_lint_pre_commit',
     version='0.0.0',
     install_requires=['cfn-lint'],
+    packages=find_packages(exclude=('tests*', 'testing*')),
+    entry_points={
+        'console_scripts': [
+            'cfn-lint-wrapper = cfn_lint_pre_commit.cfn_lint_wrapper:main'
+        ]
+    },
 )


### PR DESCRIPTION
Once cfn-lint closes https://github.com/awslabs/cfn-python-lint/pull/167
this entire project is no longer needed.